### PR TITLE
style: redesign auth forms and fix navbar layout

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -81,8 +81,15 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
     font-size: 0.9rem;
 }
 .nav-search button:hover, .btn:hover { background: var(--bg-hover); }
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-left: auto;
+    flex-shrink: 0;
+}
 .nav-links a { color: var(--text-muted); font-size: 0.9rem; }
-.nav-links a:hover { color: var(--text); }
+.nav-links a:hover { color: var(--text); text-decoration: none; }
 
 /* Main */
 .main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 2rem; }
@@ -212,10 +219,203 @@ pre {
 /* Empty state */
 .empty-state { text-align: center; padding: 3rem; color: var(--text-muted); }
 
+/* Auth card */
+.auth-card {
+    max-width: 420px;
+    margin: 4rem auto;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 2.5rem 2rem;
+}
+.auth-card h1 {
+    font-size: 1.5rem;
+    margin-bottom: 1.75rem;
+    text-align: center;
+}
+
+/* Auth form */
+.auth-form { display: flex; flex-direction: column; gap: 1.25rem; }
+.form-group { display: flex; flex-direction: column; gap: 0.4rem; }
+.form-label { font-size: 0.875rem; font-weight: 600; color: var(--text); }
+.form-input {
+    width: 100%;
+    padding: 0.6rem 0.875rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg);
+    color: var(--text);
+    font-size: 0.9rem;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.form-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15);
+}
+.form-hint { font-size: 0.8rem; color: var(--text-muted); }
+
+/* Buttons */
+.btn-primary {
+    padding: 0.65rem 1.25rem;
+    background: var(--accent);
+    color: var(--bg);
+    border: none;
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+.btn-primary:hover { opacity: 0.85; }
+
+.btn-github {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0.7rem 1.25rem;
+    background: #24292e;
+    color: #ffffff;
+    border: 1px solid #444c56;
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.15s;
+}
+.btn-github:hover { background: #2d333b; color: #ffffff; text-decoration: none; }
+
+[data-theme="light"] .btn-github { background: #24292e; border-color: #444c56; }
+
+.btn-login {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.875rem;
+}
+.btn-login:hover { border-color: var(--text-muted); color: var(--text); }
+
+/* Alerts */
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    border: 1px solid transparent;
+}
+.alert-danger {
+    background: rgba(248, 81, 73, 0.12);
+    border-color: var(--danger);
+    color: var(--danger);
+}
+.alert-success {
+    background: rgba(63, 185, 80, 0.12);
+    border-color: var(--success);
+    color: var(--success);
+}
+
+/* Token display */
+.token-display {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 1rem 0;
+}
+.token-display code {
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    word-break: break-all;
+    flex: 1;
+}
+
+/* Auth footer link */
+.auth-alt {
+    margin-top: 1.5rem;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+/* Settings / Token pages */
+.token-list { display: flex; flex-direction: column; gap: 0.75rem; }
+.token-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.875rem 1.25rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+.token-card-name { font-weight: 600; }
+.token-card-meta { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.15rem; }
+.btn-danger {
+    padding: 0.35rem 0.875rem;
+    background: transparent;
+    border: 1px solid var(--danger);
+    color: var(--danger);
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.btn-danger:hover { background: rgba(248, 81, 73, 0.12); }
+.token-new-box {
+    background: var(--bg-surface);
+    border: 1px solid var(--success);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+}
+.token-new-box code {
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    word-break: break-all;
+}
+.page-title { font-size: 1.5rem; margin-bottom: 1.75rem; }
+.page-actions { margin-bottom: 1.5rem; }
+
+/* Settings page */
+.settings-page { max-width: 640px; }
+.settings-page h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+.token-create { margin-bottom: 2rem; }
+.token-create-form {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+}
+.token-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.875rem 1.25rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+.token-info {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 1rem;
+    font-size: 0.875rem;
+}
+.token-prefix { font-family: var(--font-mono); color: var(--text-muted); }
+.token-date { color: var(--text-muted); font-size: 0.8rem; }
+.token-unused { font-style: italic; }
+.btn-sm { padding: 0.3rem 0.75rem; font-size: 0.8rem; }
+
 /* Responsive */
 @media (max-width: 640px) {
     .nav { flex-wrap: wrap; padding: 0.75rem 1rem; }
     .nav-search { max-width: 100%; order: 3; flex-basis: 100%; }
+    .nav-links { margin-left: 0; }
     .main { padding: 1rem; }
     .hero h1 { font-size: 1.5rem; }
+    .auth-card { margin: 1.5rem auto; padding: 1.5rem 1.25rem; }
 }


### PR DESCRIPTION
## Summary
- Fix `nav-links` flex layout — Sign in button no longer overlaps Publish
- Full auth card redesign: centered card, styled inputs with focus rings, proper spacing
- Add `btn-primary`, `btn-github` (dark button with icon), `btn-danger`, `btn-sm`
- Add `alert-danger`, `alert-success` alert components
- Token display box and settings page layout styles

## Visual changes
- `/login` — GitHub OAuth button (on global instance) or styled password form
- `/register` — proper card layout, field spacing
- Navbar — Sign in button correctly placed to the right of Publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)