### PR TITLE
fix: SQLite busy_timeout + btn-primary hover color

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -116,7 +116,15 @@ impl Database {
             }
         };
 
-        conn.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=ON;")?;
+        // busy_timeout: retry for up to 5 s before returning SQLITE_BUSY.
+        // Without this, the background cleanup task and HTTP request handlers
+        // race on the connection and one immediately fails with "database is
+        // locked" instead of waiting for the other to finish.
+        conn.execute_batch(
+            "PRAGMA journal_mode=DELETE; \
+             PRAGMA foreign_keys=ON; \
+             PRAGMA busy_timeout=5000;",
+        )?;
 
         Ok(Self {
             conn: Mutex::new(conn),

--- a/templates/style.css
+++ b/templates/style.css
@@ -304,7 +304,8 @@ pre {
     cursor: pointer;
     transition: opacity 0.15s;
 }
-.btn-primary:hover { opacity: 0.85; }
+/* Override the generic .btn:hover background so primary buttons stay blue. */
+.btn-primary:hover { background: var(--accent-hover); opacity: 1; }
 
 .btn-github {
     display: flex;


### PR DESCRIPTION
## Problem

Two production issues observed on Azure:

### 1. "database is locked" → token revoke HTTP 500
```
WARN duumbi_registry: Device code cleanup failed: Database error: database is locked
ERROR duumbi_registry::error: Database error: database is locked
```
The background cleanup task (`tokio::spawn` every 5 min) and HTTP request handlers (e.g. token revoke) compete for the `Mutex<Connection>`. Without `busy_timeout`, SQLite returns `SQLITE_BUSY` immediately instead of waiting, causing HTTP 500 on affected requests.

**Fix:** `PRAGMA busy_timeout=5000` — SQLite retries internally for up to 5 seconds before giving up.

### 2. "Generate token" button turns grey on hover
The `.btn:hover` rule (from the phase7-tutorial-ux fix) sets `background: var(--bg-hover-strong)` which overrides the `.btn-primary` blue background for any element with both classes (`class="btn btn-primary"`).

**Fix:** `.btn-primary:hover { background: var(--accent-hover); opacity: 1; }` so primary buttons get the proper lighter blue hover state instead of grey.

## Test plan
- [ ] `cargo test --workspace` green (50/50)
- [ ] After deploy: token revoke on Azure succeeds without "database is locked" in logs
- [ ] "Generate token" button hover shows lighter blue (`--accent-hover`), not grey

🤖 Generated with [Claude Code](https://claude.com/claude-code)